### PR TITLE
Better support for file names that contain spaces.

### DIFF
--- a/Makefile.unix
+++ b/Makefile.unix
@@ -2,16 +2,16 @@ CPP = g++
 CC = gcc
 CFLAGS = -Wall -g
 DSOFLAGS = -shared
-RM = rm
+RM = rm -rf
 RMAN = $${RMANTREE:-/usr/local/prman}
 
 all:	l2rib line.rll
 
 l2rib: 	l2rib.C
-	$(CPP) $(CFLAGS) -o l2rib l2rib.C
+	$(CPP) $(CFLAGS) -g -o l2rib l2rib.C
 
 line.rll: line.c
-	$(CC) $(DSOFLAGS) -o line.rll -I$(RMAN)/include line.c
+	$(CC) $(DSOFLAGS) -g -o line.rll -I$(RMAN)/include line.c -L$(RMAN)/lib -lprman
 
 clean:	
-	-$(RM) l2rib line.so
+	$(RM) l2rib $(wildcard *.dSYM) $(wildcard *.so) $(wildcard *.rll)

--- a/Makefile.unix
+++ b/Makefile.unix
@@ -8,10 +8,10 @@ RMAN = $${RMANTREE:-/usr/local/prman}
 all:	l2rib line.rll
 
 l2rib: 	l2rib.C
-	$(CPP) $(CFLAGS) -g -o l2rib l2rib.C
+	$(CPP) $(CFLAGS) -o l2rib l2rib.C
 
 line.rll: line.c
-	$(CC) $(DSOFLAGS) -g -o line.rll -I$(RMAN)/include line.c -L$(RMAN)/lib -lprman
+	$(CC) $(DSOFLAGS) -o line.rll -I$(RMAN)/include line.c -L$(RMAN)/lib -lprman
 
 clean:	
-	$(RM) l2rib $(wildcard *.dSYM) $(wildcard *.so) $(wildcard *.rll)
+	-$(RM) l2rib $(wildcard *.dSYM) $(wildcard *.so) $(wildcard *.rll)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ FEATURES
   quality settings
 - automatically writes out RIB for rendering depth map shadows
 
+BUILDING
+--------
+
+MacOS example:
+
+env RMANTREE=/Applications/Pixar/RenderManProServer-21.7 make -f Makefile.unix
 
 INSTALL
 -------

--- a/l2rib.C
+++ b/l2rib.C
@@ -107,6 +107,9 @@ template<> struct hash<std::string>
 #define PATHSEP "/"
 #endif
 
+#define REMOVE_SPACES(x) x.erase(std::remove(x.begin(), x.end(), ' '), x.end())
+#define REMOVE_CRS(x) x.erase(std::remove(x.begin(), x.end(), '\r'), x.end())
+
 using namespace std;
 
 struct ColourCode {
@@ -377,10 +380,15 @@ bool isFloatString(const string& s) {
 string fixFileName(const string& s)
 {
     string retval(s);
+    REMOVE_SPACES(retval);
+    REMOVE_CRS(retval);
+    
     for (string::iterator i = retval.begin(); i != retval.end(); i++) {
 	if (*i == '\\')
 	    *i = '/';
-	else
+        else if (*i == ' ')
+            *i = '_';
+        else
 	    *i = tolower(*i);
     }
     return retval;
@@ -869,7 +877,7 @@ void mpdScan(ifstream &in) {
 		    doMPD = true;
 		} else {
 		    // Add the file name to the list
-		    string filename = fixFileName(tokenize(line));
+		    string filename = fixFileName(line);
 		    mpdNames.insert(filename);
 		}
 	    }
@@ -900,8 +908,8 @@ string mpdGetNextFileName(ifstream &in) {
 	if (!token.empty() && isNumericString(token) && atoi(token.c_str()) == 0) {
 	    token = tokenize(line);
 	    if (token == "FILE") {
-		string filename = fixFileName(tokenize(line));
-		filename.replace(filename.length() - 3, 3, "rib");
+		string filename = fixFileName(line);
+		filename.replace(filename.length() -3, 3, "rib");
 		return filename;
 	    }
 	}
@@ -1002,7 +1010,9 @@ bool parseFile(ostream &out, ifstream &in, const string& partname, Bound& bound)
 		    matrix[15] = 1;
 
 		    istringstream lineStream(line.c_str());
-		    lineStream >> colour >> matrix[12] >> matrix[13] >> matrix[14] >> matrix[0] >> matrix[4] >> matrix[8] >> matrix[1] >> matrix[5] >> matrix[9] >> matrix[2] >> matrix[6] >> matrix[10] >> partname;
+		    lineStream >> colour >> matrix[12] >> matrix[13] >> matrix[14] >> matrix[0] >> matrix[4] >> matrix[8] >> matrix[1] >> matrix[5] >> matrix[9] >> matrix[2] >> matrix[6] >> matrix[10];
+                    getline(lineStream, partname);
+                    REMOVE_SPACES(partname);
 
 		    // Zero scales aren't handled very well,
 		    // particularly during ray tracing. So we need to

--- a/line.c
+++ b/line.c
@@ -37,6 +37,7 @@
 
 #define LINEWIDTH 0.001
 
+#include <math.h>
 #include <ri.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Updated Makefile.unix to better support MacOS.
Better support for file names that contain spaces.

Example:

http://omr.ldraw.org/file/123